### PR TITLE
build.sh should now build all available targets

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,10 +16,12 @@ cp -r /usr/src/i18n gluon/site/
 cd gluon
 make update
 
-for target in $(ls targets)
+for target in $(ls targets/)
 do
-	echo "Building for target $target"
-	time make -j $(($(nproc)+1)) BROKEN=1 GLUON_TARGET=$target
+	if [ -d "targets/$target" ]; then
+		echo "Building for target $target"
+		time make -j $(($(nproc)+1)) BROKEN=1 GLUON_TARGET=$target
+	fi
 done
 
 set +x

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -15,7 +15,12 @@ cp -r /usr/src/i18n gluon/site/
 # Build
 cd gluon
 make update
-time make -j $(($(nproc)+1)) BROKEN=1 GLUON_TARGET=ar71xx-generic
+
+for target in $(ls targets)
+do
+	echo "Building for target $target"
+	time make -j $(($(nproc)+1)) BROKEN=1 GLUON_TARGET=$target
+done
 
 set +x
 echo -e "\nBUILD FINISHED\n"


### PR DESCRIPTION
Damit werden jetzt stumpf Images für jedes verfügbare Target generiert. Ich bin mal davon ausgegangen, dass jedes Target funktioniert.
